### PR TITLE
Minor path-related fix for DeepInterest/prepare_dataset.sh

### DIFF
--- a/macro_benchmark/DeepInterest/prepare_dataset.sh
+++ b/macro_benchmark/DeepInterest/prepare_dataset.sh
@@ -4,6 +4,7 @@ mkdir raw_data
 cd utils
 ./0_download_raw.sh
 
+cd ..
 echo "Running md5 checksum on downloaded dataset ..."
 if md5sum -c checksum.md5; then
         echo "Dataset checksum pass"
@@ -12,6 +13,7 @@ else
         exit 1
 fi
 
+cd utils
 python 1_convert_pd.py
 python 2_remap_id.py
 cd ../din


### PR DESCRIPTION
The issue is that prepare_dataset.sh is hitting an error related to not being able to find checksum.md5.  Since checksum.md5 includes the relative path of 'raw_data/*.json', the easiest fix seems to be to temporarily drop back to the main DeepInterest directory.