### PR TITLE
Avoid 'pip3 uninstall' query in Mask_RCNN

### DIFF
--- a/macro_benchmark/Mask_RCNN/setup.sh
+++ b/macro_benchmark/Mask_RCNN/setup.sh
@@ -3,7 +3,7 @@
 pip3 install imgaug
 pip3 install opencv-python
 pip3 install 'keras==2.1.6'
-pip3 uninstall scikit-image
+pip3 uninstall -y scikit-image
 pip3 install scikit-image==0.13.1
 pip3 install cython
 apt update && apt install -y libsm6 libxext6


### PR DESCRIPTION
Minor change to the Mask_RCNN/setup.sh script -- avoid the manual "y/n" query required for 'pip3 uninstall scikit-image'.